### PR TITLE
Fixed System::nanoTime comparison according to System::nanoTime JavaDoc

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/BasicDB.java
+++ b/core/src/main/java/com/yahoo/ycsb/BasicDB.java
@@ -70,7 +70,7 @@ public class BasicDB extends DB
             final long deadline = now + delayNs;
             do {
                 LockSupport.parkNanos(deadline - now);
-            } while ((now = System.nanoTime()) < deadline && !Thread.interrupted());
+            } while (((now = System.nanoTime())- deadline) < 0 && !Thread.interrupted());
 		}
 	}
 

--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -288,12 +288,12 @@ class ClientThread extends Thread
 	}
 
     static void sleepUntil(long deadline) {
-        long now = System.nanoTime();
-        while((now = System.nanoTime()) < deadline) {
-            if (!_spinSleep) {
-                LockSupport.parkNanos(deadline - now);
-            }
-        }
+		long untilDeadline;
+		while ((untilDeadline = (deadline - System.nanoTime())) > 0) {
+			if (!_spinSleep) {
+				LockSupport.parkNanos(untilDeadline);
+			}
+		}
     }
     private void throttleNanos(long startTimeNanos) {
         //throttle the operations

--- a/core/src/main/java/com/yahoo/ycsb/GoodBadUglyDB.java
+++ b/core/src/main/java/com/yahoo/ycsb/GoodBadUglyDB.java
@@ -69,7 +69,7 @@ public class GoodBadUglyDB extends DB {
             final long deadline = now + delayNs;
             do {
                 LockSupport.parkNanos(deadline - now);
-            } while ((now = System.nanoTime()) < deadline && !Thread.interrupted());
+            } while (((now = System.nanoTime()) - deadline) < 0 && !Thread.interrupted());
         }
         finally {
             lock.unlock();


### PR DESCRIPTION
System::nanoTime can start in some fixed but arbitrary origin time.
In order to safely compare against it, is necessary to use
differences instead of direct comparisons.